### PR TITLE
Create AddProblem, Form and Alert components

### DIFF
--- a/src/components/alert/custom-alert.js
+++ b/src/components/alert/custom-alert.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+import { Alert } from 'react-bootstrap';
+
+const alert = (show) => {
+  if (show) {
+    return (
+      <Alert bsStyle='success'>Submission Completed!</Alert>
+    );
+  }
+};
+
+class CustomAlert extends Component {
+  render () {
+    return (
+      <div>
+        { alert(this.props.showAlert) }
+      </div>
+    );
+  }
+}
+
+export default CustomAlert;

--- a/src/components/form/add-problem-form.js
+++ b/src/components/form/add-problem-form.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import { Button, ControlLabel, FormGroup, FormControl, HelpBlock } from 'react-bootstrap';
+
+import AddTagForm from './add-tag-form';
+import AddTextAreaForm from './add-text-area-form';
+
+class AddProblemForm extends Component {
+  render () {
+    return (
+      <form onSubmit={this.props.handleSubmit}>
+        <FieldGroup
+          className='form-control-field'
+          type='text'
+          label='Name'
+          placeholder='Enter name'
+          onChange={this.props.handleProblemNameChange} />
+        <FieldGroup
+          className='form-control-field'
+          id='form-control-description'
+          componentClass='textarea'
+          type='text'
+          label='Description'
+          placeholder='Enter description'
+          onChange={this.props.handleProblemDescriptionChange} />
+        <FieldGroup
+          className='form-control-field'
+          type='text'
+          label='Tip'
+          placeholder='Enter tip'
+          onChange={this.props.handleProblemTipChange} />
+        <AddTagForm
+          tags={this.props.tags}
+          handleTagChange={this.props.handleTagChange}
+          handleRemoveTag={this.props.handleRemoveTag}
+          handleAddTag={this.props.handleAddTag} />
+        <AddTextAreaForm
+          label='Tests'
+          data={this.props.tests}
+          handleTextAreaChange={this.props.handleTestChange}
+          handleRemoveComponent={this.props.handleRemoveTest}
+          handleAddComponent={this.props.handleAddTest} />
+        <Button bsStyle='primary' type='submit' onClick={this.props.handleSubmit}>
+          Submit
+        </Button>
+      </form>
+    );
+  }
+}
+
+function FieldGroup ({ id, label, help, ...props }) {
+  return (
+    <FormGroup controlId={id}>
+      <ControlLabel>{ label }</ControlLabel>
+      <FormControl {...props} />
+      { help && <HelpBlock>{help}</HelpBlock> }
+    </FormGroup>
+  );
+}
+
+export default AddProblemForm;

--- a/src/components/form/add-tag-form.js
+++ b/src/components/form/add-tag-form.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+import { Button, ControlLabel, FormGroup } from 'react-bootstrap';
+
+import './form.css';
+
+class AddTagForm extends Component {
+  render () {
+    return (
+      <FormGroup>
+        <ControlLabel>Tags</ControlLabel>
+        { this.props.tags.map((tag, index) => (
+          <div class='input-group mb-3'>
+            <input
+              id='tag-name'
+              type='text'
+              class='form-control'
+              placeholder={`Tag #${index + 1} name`}
+              value={tag}
+              onChange={this.props.handleTagChange(index)} />
+            <Button
+              id='remove-tag-btn'
+              class='btn btn-outline-secondary input-group-append'
+              onClick={this.props.handleRemoveTag(index)}
+            > {'-'} </Button>
+          </div>
+        )) }
+        <div>
+          <Button
+            id='add-tag-btn'
+            onClick={this.props.handleAddTag}
+          > {'+'} </Button>
+        </div>
+      </FormGroup>
+    );
+  }
+}
+
+export default AddTagForm;

--- a/src/components/form/add-text-area-form.js
+++ b/src/components/form/add-text-area-form.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import { Button, ControlLabel, FormGroup } from 'react-bootstrap';
+
+import './form.css';
+
+class AddTextAreaForm extends Component {
+  render () {
+    return (
+      <FormGroup>
+        <ControlLabel> {this.props.label} </ControlLabel>
+        { this.props.data.map((component, index) => (
+          <div class='input-group mb-3'>
+            {Object.keys(component).map((key) => (
+              <textarea
+                id='textarea-input'
+                type='text'
+                class='form-control'
+                placeholder={`#${index + 1} ${key}`}
+                value={component.key}
+                onChange={(event) => this.props.handleTextAreaChange(key, index, event)} />
+            ))}
+            <Button
+              id='remove-textarea-btn'
+              class='btn btn-outline-secondary input-group-append'
+              onClick={this.props.handleRemoveComponent(index)}
+            > {'-'} </Button>
+          </div>
+        )) }
+        <div>
+          <Button
+            id='add-text-area-btn'
+            onClick={this.props.handleAddComponent}
+          > {'+'} </Button>
+        </div>
+      </FormGroup>
+    );
+  }
+}
+
+export default AddTextAreaForm;

--- a/src/components/form/form.css
+++ b/src/components/form/form.css
@@ -1,0 +1,81 @@
+.form-control-field {
+  width: 40%;
+}
+
+#form-control-description {
+  height: 200px;
+}
+
+#tag-name {
+  width: 80%;
+  border-radius: 3px;
+  margin-top: 1%;
+}
+
+#textarea-input {
+  width: 20%;
+  height: 34.7px;
+  border-radius: 3px;
+  margin-top: 1%;
+}
+
+#add-tag-btn {
+  margin-top: 1%;
+  position: inherit;
+  background-color: #ddd;
+}
+
+#remove-tag-btn {
+  margin-top: 1%;
+  margin-left: 2%;
+  background-color: #337ab7;
+  border-color: #337ab7;
+  color: #fff;
+}
+
+#add-text-area-btn {
+  margin-top: 1%;
+  padding: 5.8px 13px 6px 13px;
+  position: inherit;
+  background-color: #ddd;
+}
+
+#remove-textarea-btn {
+  margin-top: 1%;
+  margin-left: 0.5%;
+  padding: 3.7px 13px 4px;
+  background-color: #337ab7;
+  border-color: #337ab7;
+  color: #fff;
+}
+
+#add-tag-btn,
+#remove-tag-btn,
+#add-textarea-btn,
+#remove-textarea-btn {
+  padding-left: 13px;
+  padding-right: 13px;
+  padding-top: 5.8px;
+  padding-bottom: 5.8px;
+}
+
+#remove-tag-btn:hover,
+#remove-textarea-btn:hover {
+  background-color: #1e496d;
+  border-color: #1e496d;
+  color: #fff;
+}
+
+.button-submit {
+  margin-bottom: 2%;
+  padding: 8px 15px;
+  border-radius: 3px;
+  background-color: #337ab7;
+  color: #fff;
+}
+
+.button-submit:hover {
+  background-color: #1e496d;
+  border-color: #1e496d;
+  color: #fff;
+}

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -1,5 +1,5 @@
 .react-bs-container-header {
-  border-collapse: collapse;
+  border-radius: 3px;
   color: #fefefe;
   background-color: #375a7f;
 }

--- a/src/config/router.js
+++ b/src/config/router.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import Welcome from '../containers/welcome/welcome';
 import Courses from '../containers/courses/courses';
-import Problems from '../containers/problems/problems';
+import ProblemCollection from '../containers/problems/problem-collection';
+import AddProblem from '../containers/problems/add-problem';
 import Ide from '../components/ide/ide';
 import './router.css';
 
@@ -12,8 +13,9 @@ const Router = () => {
       <Switch>
         <Route exact path='/' component={Welcome} />
         <Route path='/courses' component={Courses} />
-        <Route path='/problems' component={Problems} />
+        <Route path='/problems' component={ProblemCollection} />
         <Route path='/ide' component={Ide} />
+        <Route path='/addProblem' component={AddProblem} />
       </Switch>
     </div>
   );

--- a/src/constants/problem-constants.js
+++ b/src/constants/problem-constants.js
@@ -5,3 +5,7 @@ export const HEADERS_TABLE = {
   created: { label: 'Created', width: '250' },
   solved: { label: 'Solved', width: '80' } // check how we're going to deal with solving
 };
+
+export const URLS = {
+  addProblem: '/addProblem'
+};

--- a/src/containers/problems/add-problem.js
+++ b/src/containers/problems/add-problem.js
@@ -1,0 +1,134 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { PageHeader } from 'react-bootstrap';
+
+import * as problemAction from '../../actions/problem';
+import AddProblemForm from '../../components/form/add-problem-form';
+import CustomAlert from '../../components/alert/custom-alert';
+import './style/problems.css';
+
+class AddProblem extends Component {
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      showAlert: false,
+      name: '',
+      description: '',
+      tip: '',
+      tags: [''],
+      tests: [{ name: '', tip: '', input: '', output: '' }]
+    };
+  }
+
+  handleProblemNameChange = event => {
+    this.setState({ name: event.target.value });
+  };
+
+  handleProblemDescriptionChange = event => {
+    this.setState({ description: event.target.value });
+  };
+
+  handleProblemTipChange = event => {
+    this.setState({ tip: event.target.value });
+  };
+
+  // <----------------------- Adding tags -----------------------> //
+  handleTagChange = index => event => {
+    const newTags = this.state.tags.map((tag, tindex) => {
+      if (index !== tindex) return tag;
+      return event.target.value;
+    });
+
+    this.setState({ tags: newTags });
+  };
+
+  handleAddTag = () => {
+    this.setState({
+      tags: this.state.tags.concat([''])
+    });
+  };
+
+  handleRemoveTag = index => () => {
+    this.setState({
+      tags: this.state.tags.filter((t, tindex) => index !== tindex)
+    });
+  };
+  // <-----------------------------------------------------------> //
+
+  // <----------------------- Adding tests -----------------------> //
+  handleTestChange = (key, index, event) => {
+    const newTests = this.state.tests.map((test, tindex) => {
+      if (index !== tindex) return test;
+      return { ...test, [key]: event.target.value };
+    });
+
+    this.setState({ tests: newTests });
+  };
+
+  handleAddTest = () => {
+    this.setState({
+      tests: this.state.tests.concat([{ name: '', tip: '', input: '', output: '' }])
+    });
+  };
+
+  handleRemoveTest = index => () => {
+    this.setState({
+      tests: this.state.tests.filter((t, tindex) => index !== tindex)
+    });
+  };
+  // <------------------------------------------------------------> //
+
+  handleSubmit = event => {
+    event.preventDefault();
+
+    const problem = {
+      name: this.state.name,
+      description: this.state.description,
+      tip: this.state.tip,
+      tags: this.state.tags,
+      tests: this.state.tests
+    };
+    this.props.onCreateProblem(problem);
+    this.handleShowAlert();
+  };
+
+  handleShowAlert = () => {
+    this.setState({
+      showAlert: true
+    });
+  };
+
+  render () {
+    return (
+      <div id='add-problem-form'>
+        <PageHeader>
+          Add Problem
+        </PageHeader>
+        <CustomAlert showAlert={this.state.showAlert} />
+        <AddProblemForm
+          tags={this.state.tags}
+          tests={this.state.tests}
+          handleProblemNameChange={this.handleProblemNameChange}
+          handleProblemDescriptionChange={this.handleProblemDescriptionChange}
+          handleProblemTipChange={this.handleProblemTipChange}
+          handleAddTag={this.handleAddTag}
+          handleTagChange={this.handleTagChange}
+          handleRemoveTag={this.handleRemoveTag}
+          handleTestChange={this.handleTestChange}
+          handleAddTest={this.handleAddTest}
+          handleRemoveTest={this.handleRemoveTest}
+          handleSubmit={this.handleSubmit}
+        />
+      </div>
+    );
+  }
+}
+
+const mapDispatchToProps = dispatch => (
+  {
+    onCreateProblem: (problem) => dispatch(problemAction.createProblem(problem))
+  }
+);
+
+export default connect(null, mapDispatchToProps)(AddProblem);

--- a/src/containers/problems/problem-collection.js
+++ b/src/containers/problems/problem-collection.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
+import { Button, PageHeader } from 'react-bootstrap';
 import { connect } from 'react-redux';
+
+import { HEADERS_TABLE, URLS } from '../../constants/problem-constants';
 import * as problemAction from '../../actions/problem';
+import Spinner from '../../components/spinner/spinner';
 import Table from '../../components/table/table';
 import './style/problems.css';
-import Spinner from '../../components/spinner/spinner';
-import { HEADERS_TABLE } from '../../constants/problem-constants';
 
-class Problems extends Component {
+class ProblemCollection extends Component {
   render () {
     if (this.props.isLoading) {
       return <Spinner />;
@@ -14,6 +16,12 @@ class Problems extends Component {
 
     return (
       <div className='problems-container'>
+        <PageHeader>
+          Problems
+        </PageHeader>
+        <div id='add-problem-div'>
+          <Button bsStyle='primary' href={URLS.addProblem}>Add Problem</Button>
+        </div>
         <Table
           headers={HEADERS_TABLE}
           data={this.props.problems}
@@ -40,4 +48,4 @@ const mapDispatchToProps = dispatch => (
   }
 );
 
-export default connect(mapStateToProps, mapDispatchToProps)(Problems);
+export default connect(mapStateToProps, mapDispatchToProps)(ProblemCollection);

--- a/src/containers/problems/style/problems.css
+++ b/src/containers/problems/style/problems.css
@@ -1,5 +1,9 @@
 .problems-container {
-  margin-top: 5%;
+  margin-top: 2%;
   margin-left: 5%;
   margin-right: 5%;
+}
+
+#add-problem-form {
+  margin: 2% 5% 0;
 }

--- a/src/reducers/problem.js
+++ b/src/reducers/problem.js
@@ -14,6 +14,17 @@ const ProblemReducer = (state = initialState, action) => {
         isLoading: false,
         problems: action.problems
       };
+    case action.CREATE_PROBLEM:
+      return {
+        ...state,
+        problem: {
+          name: action.name,
+          description: action.description,
+          tip: action.tip,
+          tags: action.tags,
+          tests: action.tests
+        }
+      };
     default: return state;
   }
 };


### PR DESCRIPTION
This PR is able to:
- Create a `AddProblem` component to accept a form and submit a new problem
- Create a button on `Problems` page to redirect to `AddProblem` page
- Make adjustments on `Router`, `Utility` and other CSS to support new changes

![add_problem](https://user-images.githubusercontent.com/7563089/51631965-e2774480-1f2c-11e9-8ca9-fbb05f4c5207.gif)